### PR TITLE
Add SwiftUI sample for estimating battery time

### DIFF
--- a/BatteryLimitTime/Assets.xcassets/Contents.json
+++ b/BatteryLimitTime/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/BatteryLimitTime/BatteryEstimator.swift
+++ b/BatteryLimitTime/BatteryEstimator.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Combine
+import SwiftUI
+
+final class BatteryEstimator: ObservableObject {
+    @Published var batteryLevel: Float = UIDevice.current.batteryLevel
+    @Published var batteryState: UIDevice.BatteryState = UIDevice.current.batteryState
+    @Published var remainingTime: TimeInterval?
+
+    private var lastRecord: (date: Date, level: Float)?
+    private var avgSecondsPerPercent: TimeInterval = 0
+    private var sampleCount: Int = 0
+
+    init() {
+        UIDevice.current.isBatteryMonitoringEnabled = true
+        batteryLevel = UIDevice.current.batteryLevel
+        batteryState = UIDevice.current.batteryState
+        lastRecord = (Date(), batteryLevel)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(batteryLevelChanged),
+                                               name: UIDevice.batteryLevelDidChangeNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(batteryStateChanged),
+                                               name: UIDevice.batteryStateDidChangeNotification,
+                                               object: nil)
+    }
+
+    @objc private func batteryLevelChanged() {
+        let level = UIDevice.current.batteryLevel
+        let now = Date()
+
+        if batteryState == .unplugged || batteryState == .unknown {
+            if let last = lastRecord, level < last.level {
+                let deltaLevel = last.level - level
+                let deltaTime = now.timeIntervalSince(last.date)
+                let timePerPercent = deltaTime / Double(deltaLevel * 100)
+                avgSecondsPerPercent = ((avgSecondsPerPercent * Double(sampleCount)) + timePerPercent) / Double(sampleCount + 1)
+                sampleCount += 1
+            }
+        }
+
+        lastRecord = (now, level)
+        batteryLevel = level
+        updateRemaining()
+    }
+
+    @objc private func batteryStateChanged() {
+        batteryState = UIDevice.current.batteryState
+        updateRemaining()
+    }
+
+    private func updateRemaining() {
+        guard batteryState == .unplugged || batteryState == .unknown else {
+            remainingTime = nil
+            return
+        }
+        let remainingPercent = max(batteryLevel, 0) * 100
+        remainingTime = avgSecondsPerPercent * Double(remainingPercent)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+}

--- a/BatteryLimitTime/BatteryLimitTimeApp.swift
+++ b/BatteryLimitTime/BatteryLimitTimeApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct BatteryLimitTimeApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/BatteryLimitTime/ContentView.swift
+++ b/BatteryLimitTime/ContentView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var estimator = BatteryEstimator()
+
+    var body: some View {
+        ZStack {
+            LinearGradient(gradient: Gradient(colors: [Color(.systemBackground), Color(.secondarySystemBackground)]),
+                           startPoint: .topLeading,
+                           endPoint: .bottomTrailing)
+                .ignoresSafeArea()
+
+            VStack(spacing: 32) {
+                Text(timeString)
+                    .font(.system(size: 34, weight: .semibold, design: .rounded))
+                    .multilineTextAlignment(.center)
+                Text(statusString)
+                    .font(.system(size: 16))
+                    .foregroundColor(.secondary)
+            }
+            .padding(40)
+        }
+    }
+
+    private var timeString: String {
+        if let seconds = estimator.remainingTime {
+            let hours = Int(seconds) / 3600
+            let minutes = Int(seconds.truncatingRemainder(dividingBy: 3600)) / 60
+            return String(format: "残り時間: %d時間%d分（参考値）", hours, minutes)
+        } else {
+            return "計測中..."
+        }
+    }
+
+    private var statusString: String {
+        let levelPercent = Int(estimator.batteryLevel * 100)
+        switch estimator.batteryState {
+        case .charging, .full:
+            return "充電中 \(levelPercent)%"
+        case .unplugged, .unknown:
+            return "バッテリー \(levelPercent)%"
+        @unknown default:
+            return "バッテリー \(levelPercent)%"
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/BatteryLimitTime/Info.plist
+++ b/BatteryLimitTime/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>BatteryLimitTime</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.BatteryLimitTime</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add SwiftUI app estimating remaining battery time using historical drain rate
- show simple modern interface with gradient background and large time display

## Testing
- `swiftc BatteryLimitTime/BatteryLimitTimeApp.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68b7ff31b8f483248f865ecfe0d46903